### PR TITLE
Update import of genlaguerre

### DIFF
--- a/fastoverlap/utils.py
+++ b/fastoverlap/utils.py
@@ -10,8 +10,7 @@ from heapq import heappop, heappush
 import numpy as np
 from numpy.linalg import norm
 from numpy import sin, cos, sqrt, pi, exp
-from scipy.special import eval_jacobi, gamma
-from scipy.special.orthogonal import genlaguerre, eval_genlaguerre
+from scipy.special import eval_jacobi, gamma, genlaguerre, eval_genlaguerre
 
 try:
     from scipy.special.basic import factorial, comb


### PR DESCRIPTION
Using python3.8 and scipy 1.9 I get and import error running the examples.

It seems scipy moved `eval_genlaguerre` at some point to `special` instead of `special.orthogonal`.  I've simply updated the import path.  If you care about compatibility with older scipy, I can also put a try/except.